### PR TITLE
Update exploit_gui.py to fix dark theme compatibility for Help widget 

### DIFF
--- a/exploit_gui.py
+++ b/exploit_gui.py
@@ -7,6 +7,7 @@ import tkinter as tk
 from tkinter import ttk, scrolledtext, filedialog, simpledialog, messagebox
 import threading, queue, sys, os, time, socket, io, hmac, hashlib, binascii, base64, traceback
 import subprocess
+import shutil
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import mysrp as srp
@@ -733,6 +734,69 @@ class ExploitGUI:
         self._build_ui()
         self._poll_log()
 
+    def _dark_mode_enabled(self):
+        if sys.platform == 'darwin':
+            return self._macos_dark_mode_enabled()
+        if sys.platform == 'win32':
+            return self._windows_dark_mode_enabled()
+        return self._linux_dark_mode_enabled()
+
+    def _macos_dark_mode_enabled(self):
+        try:
+            result = subprocess.run(
+                ['defaults', 'read', '-g', 'AppleInterfaceStyle'],
+                capture_output=True, text=True, check=False
+            )
+            return result.stdout.strip().lower() == 'dark'
+        except Exception:
+            return False
+
+    def _windows_dark_mode_enabled(self):
+        try:
+            import winreg
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+            ) as key:
+                value, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
+                return value == 0
+        except Exception:
+            return False
+
+    def _linux_dark_mode_enabled(self):
+        try:
+            theme = os.environ.get('GTK_THEME', '') + ' ' + os.environ.get('QT_STYLE_OVERRIDE', '')
+            if 'dark' in theme.lower():
+                return True
+            if shutil.which('gsettings'):
+                result = subprocess.run(
+                    ['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'],
+                    capture_output=True, text=True, check=False
+                )
+                if 'prefer-dark' in result.stdout.lower():
+                    return True
+                result = subprocess.run(
+                    ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
+                    capture_output=True, text=True, check=False
+                )
+                if 'dark' in result.stdout.lower():
+                    return True
+            if shutil.which('xfconf-query'):
+                result = subprocess.run(
+                    ['xfconf-query', '-c', 'xsettings', '-p', '/Net/ThemeName'],
+                    capture_output=True, text=True, check=False
+                )
+                if 'dark' in result.stdout.lower():
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def _help_widget_colors(self):
+        if self._dark_mode_enabled():
+            return '#1e1e1e', '#f5f5f5', '#f5f5f5', '#264f78'
+        return '#f5f5f5', '#000000', '#000000', '#add6ff'
+
     def _build_ui(self):
         # ── Preset selector (top bar row 1) ──
         pf = ttk.Frame(self.root, padding=(10, 5))
@@ -1073,8 +1137,19 @@ class ExploitGUI:
             "  - Block ISP updates to prevent remote firmware changes\n"
             "  - Factory reset will undo root (avoid if possible)"
         )
-        help_widget = scrolledtext.ScrolledText(hf, font=("Consolas", 10),
-                                                 wrap=tk.WORD, bg='#f5f5f5')
+        help_bg, help_fg, help_insert_bg, help_select_bg = self._help_widget_colors()
+        help_widget = scrolledtext.ScrolledText(
+            hf,
+            font=("Consolas", 10),
+            wrap=tk.WORD,
+            bg=help_bg,
+            fg=help_fg,
+            insertbackground=help_insert_bg,
+            selectbackground=help_select_bg,
+            relief=tk.FLAT,
+            borderwidth=1,
+            highlightthickness=1
+        )
         help_widget.pack(fill=tk.BOTH, expand=True)
         help_widget.insert('1.0', help_text)
         help_widget.config(state=tk.DISABLED)


### PR DESCRIPTION
Updates the exploit gui with dark theme detection for macOS, Windows, and Linux.

Added full dark mode detection for:
macOS via defaults read -g AppleInterfaceStyle

Windows via registry AppsUseLightTheme

Linux via GTK/QT theme env vars and GNOME/XFCE theme queries

Fixes #6